### PR TITLE
:art: Payload에 nickname 추가, views.py 인증코드 예외사항추가 #8

### DIFF
--- a/users/serializers.py
+++ b/users/serializers.py
@@ -39,7 +39,6 @@ class VerifySerializer(serializers.Serializer):
             return data
 
 
-
 # 마이페이지의 팔로잉 리스트
 class FollowListSerializer(serializers.ModelSerializer):
     nickname = serializers.CharField()
@@ -57,7 +56,6 @@ class UserArticlesSerializer(serializers.ModelSerializer):
         model = Article
         fields = "__all__"
 
-        
 
 # 마이페이지용
 class UserPageSerializer(serializers.ModelSerializer):
@@ -92,4 +90,5 @@ class UserTokenObtainPairSerializer(TokenObtainPairSerializer):
     def get_token(cls, user):
         token = super().get_token(user)
         token["email"] = user.email
+        token["nickname"] = user.nickname
         return token

--- a/users/views.py
+++ b/users/views.py
@@ -25,11 +25,14 @@ class AthntCodeCreateView(APIView):
             return Response(
                 {"message": "이미 가입된 이메일입니다."}, status=status.HTTP_400_BAD_REQUEST
             )
+        code = Verify.objects.filter(email=email)
+        if code.exists():
+            code.delete()
         athnt_code = str(randint(1, 999999)).zfill(6)
         message = EmailMessage(
             "ChangeART [Verification Code]",
             f"인증코드 [{athnt_code}]",
-            "changeart@gmail.com",
+            "HOST@gmail.com",
             [email],
         )
         authen_Code = Verify(email=email, athnt_code=athnt_code)


### PR DESCRIPTION
users/serializers.py : UserTokenObtainPairSerializer에 user.nickname을 추가하여 
                                    payload값에 저장하였습니다 
users/views.py : AthntCodeCreateView 같은 메일이 인증코드를 중복으로 받을 시 
                            예전 인증코드를 삭제하도록 했습니다.
                            host의 이메일을 노출하지 않도록 수정했습니다